### PR TITLE
Add CV functionality to Teleop Code

### DIFF
--- a/src/main/java/org/usfirst/frc/team2473/robot/OI.java
+++ b/src/main/java/org/usfirst/frc/team2473/robot/OI.java
@@ -1,14 +1,17 @@
 package org.usfirst.frc.team2473.robot;
 
 import edu.wpi.first.wpilibj.Joystick;
+import edu.wpi.first.wpilibj.buttons.JoystickButton;
 
 public class OI {
 	private Joystick throttle;
 	private Joystick wheel;
+	private JoystickButton cvButton;
 
 	public OI() {
 		throttle = new Joystick(2);		
-		wheel = new Joystick(0);		
+		wheel = new Joystick(0);
+		cvButton = new JoystickButton(wheel, 7);	
 	}
 	
 	public Joystick getThrottle() {
@@ -17,5 +20,9 @@ public class OI {
 
 	public Joystick getWheel() {
 		return wheel;
+	}
+
+	public JoystickButton getCVButton() {
+		return cvButton;
 	}
 }

--- a/src/main/java/org/usfirst/frc/team2473/robot/commands/TeleopDrive.java
+++ b/src/main/java/org/usfirst/frc/team2473/robot/commands/TeleopDrive.java
@@ -15,13 +15,28 @@ import org.usfirst.frc.team2473.robot.Robot;
  */
 public class TeleopDrive extends Command {
 	
+	private AlignToHatch alignToHatch;
+
 	public TeleopDrive() {
 		requires(Robot.driveSubsystem);
 	}
 
 	@Override
+	protected void initialize() {
+		alignToHatch = new AlignToHatch();
+	}
+
+	@Override
 	protected void execute() {
-		Robot.driveSubsystem.teleopDrive(Robot.oi.getThrottle().getZ(), Robot.oi.getWheel().getX());
+		double throttleZ = Robot.oi.getThrottle().getZ();
+		double wheelX = Robot.oi.getWheel().getX();
+		boolean cvButtonPressed = Robot.oi.getCVButton().get();
+
+		if (cvButtonPressed && throttleZ == 0 && wheelX == 0) { // ensures that the CV button is pressed AND the throttle and wheel are zeroed before using CV
+			alignToHatch.move();
+		} else {
+			Robot.driveSubsystem.teleopDrive(throttleZ, wheelX);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
When the CV button on the wheel is pressed and the throttle and wheel
are zeroed, the AlignToHatch CV code will start running, allowing the
drivers to use CV in the teleop period. Furthermore, if the drivers want
to take control at any point, the CV code will stop running when the
drivers release the CV button or move the throttle or wheel.